### PR TITLE
fix: snowfall height

### DIFF
--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -34,7 +34,7 @@ import Snowfall from 'react-snowfall'
     <ViewTransitions />
 </head>
 <body class="bg-lightgrey w-full h-full min-h-screen text-black dark:text-white transition ease-in-out delay-50 flex flex-col items-center bg-[url('/img/skies.svg')] bg-cover">
-    <div class="top-0 absolute -z-10 min-h-screen w-screen">
+    <div id="snowfall" class="top-0 absolute -z-10 min-h-screen w-screen">
         <Snowfall color="#c7d0e6" client:only/>
     </div>
     <Nav />
@@ -70,6 +70,13 @@ import Snowfall from 'react-snowfall'
         document.documentElement.classList.add("dark");
     }
     window.localStorage.setItem("theme", theme);
+</script>
+
+<script is:inline>
+    const snowfallHeight = document.body.scrollHeight;
+    const snowfallElement = document.getElementById('snowfall');
+
+    snowfallElement.style.height = `${snowfallHeight}px`;
 </script>
 
 <style is:global>


### PR DESCRIPTION
The current snowfall effect has the height of the initial viewport which is causing a visible edge where the effect doesn't fill the entire body.

Solved by setting the height to the scrollHeight of the body.